### PR TITLE
Allow state to run in docker

### DIFF
--- a/opencrowbar/init.sls
+++ b/opencrowbar/init.sls
@@ -2,11 +2,13 @@
 {% set use_develop = salt['config.get']('opencrowbar:use_develop', False) %}
 {% set with_download = salt['config.get']('opencrowbar:with_download', False) %}
 
+{% if grains['virtual_subtype'] != 'Docker' %}
 iptables:
   service.dead
 
 permissive:
   selinux.mode
+{% endif %}
 
 ocb-repo:
   pkgrepo.managed:


### PR DESCRIPTION
Using the following can run this from within in the centos:6.6 docker container:
yum install -y epel-release
yum install -y salt-minion
yum install -y git
mkdir -p /srv/salt
git clone https://github.com/saltstack-formulas/opencrowbar-formula.git
cp -r opencrowbar /srv/salt

salt-call --local state.sls opencrowbar
